### PR TITLE
BUGFIX - get users from graph API

### DIFF
--- a/src/.e2e/.env.local02
+++ b/src/.e2e/.env.local02
@@ -1,0 +1,7 @@
+env=local
+baseUrl=http://localhost:7211/api
+baseUrlRoles=http://localhost:7203/api
+b2cLoginUrl=https://leavesystemdev02.b2clogin.com/tfp/leavesystemdev02.onmicrosoft.com/B2C_1A_ROPC_AUTH
+b2cClientId=86a72e60-5d06-4189-98c7-cbff9962b222
+b2cClientScope=https://leavesystemdev02.onmicrosoft.com/4dba3775-b4d0-c9b9-3da4-d7a390817e53/API.Access
+userRoleB2C=173a9197-68a0-429d-9057-597769a8a9aa

--- a/src/LeaveSystem.Functions/LeaveSystem.Functions/Employees/EmployeesFunction.cs
+++ b/src/LeaveSystem.Functions/LeaveSystem.Functions/Employees/EmployeesFunction.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.IdentityModel.Tokens;
 
 public class EmployeesFunction(IGetUserRepository getUserRepository)
 {
@@ -27,7 +26,7 @@ public class EmployeesFunction(IGetUserRepository getUserRepository)
             SqlQuery = $"SELECT c.id FROM c JOIN r IN c. roles WHERE r = \"{nameof(RoleType.Employee)}\"",
             Connection  = "CosmosDBConnection")] IEnumerable<RolesDto> roles, CancellationToken cancellationToken)
     {
-        var result = !roles.IsNullOrEmpty() ? await getUserRepository.GetUsers(roles.Select(x => x.Id).ToArray(), cancellationToken) : Result.Ok<IReadOnlyCollection<IGetUserRepository.User>, Error>([]);
+        var result = roles is null || !roles.Any() ? Result.Ok<IReadOnlyCollection<IGetUserRepository.User>, Error>([]) : await getUserRepository.GetUsers(roles.Select(x => x.Id).ToArray(), cancellationToken);
 
         return result.Match(
             (employees) => new OkObjectResult(employees.ToPagedListResponse()),


### PR DESCRIPTION
Error from graph API
> Too many child clauses specified in search filter expression containing 'OR' operators: 23. Max allowed: 15.